### PR TITLE
Fix encoding errors when response has non-ascii characters

### DIFF
--- a/responsediff/response.py
+++ b/responsediff/response.py
@@ -7,7 +7,6 @@ import subprocess
 import tempfile
 
 from bs4 import BeautifulSoup
-import six
 
 from .exceptions import DiffsFound
 
@@ -91,8 +90,7 @@ class Response(object):
         if selector:
             soup = BeautifulSoup(response.content, 'html5lib')
             elements = soup.select(selector)
-            content = '\n---\n'.join(
-                map(lambda e: six.text_type(e), elements))
+            content = '\n---\n'.join(map(str, elements))
             mode = 'w+'
         else:
             content = response.content


### PR DESCRIPTION
When using selectors, if selected tags contain non-ascii characters, writing the content fixture fails because we're writing to it in text mode. Using `str` instead will work in all cases because it will force BeautifulSoup to output only ascii characters.