### PR TITLE
Fix encoding errors when response has non-ascii characters

### DIFF
--- a/responsediff/response.py
+++ b/responsediff/response.py
@@ -7,7 +7,6 @@ import subprocess
 import tempfile
 
 from bs4 import BeautifulSoup
-import six
 
 from .exceptions import DiffsFound
 
@@ -91,8 +90,7 @@ class Response(object):
         if selector:
             soup = BeautifulSoup(response.content, 'html5lib')
             elements = soup.select(selector)
-            content = '\n---\n'.join(
-                map(lambda e: six.text_type(e), elements))
+            content = '\n---\n'.join(map(str, elements))
             mode = 'w+'
         else:
             content = response.content

--- a/responsediff/tests/test_mixin.py
+++ b/responsediff/tests/test_mixin.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import re
 import shutil
@@ -33,6 +34,15 @@ class MixinTest(ResponseDiffTestMixin, test.TestCase):
 
     def test_assertNoDiffSelector(self):  # noqa
         self.assertResponseDiffEmpty(test.Client().get('/admin/'), 'h1, p')
+
+    def test_assertNoDiffSelector_non_ascii(self):  # noqa
+        response = test.Client().get('/admin/')
+
+        response.content = '<h1>à</h1>' if six.PY3 else u'<h1>à</h1>'
+
+        # Should fail, but not with a decoding error
+        with self.assertRaises(DiffsFound):
+            self.assertResponseDiffEmpty(response, 'h1')
 
     def test_assertWebsiteSame(self):  # noqa
         subject = Response.for_test(self, url='/')


### PR DESCRIPTION
Fixes: E           UnicodeEncodeError: 'ascii' codec can't encode characters in position 4-11: ordinal not in range(128)